### PR TITLE
delete presets before loading new ones

### DIFF
--- a/src/lib/load/load-presets.ts
+++ b/src/lib/load/load-presets.ts
@@ -1,14 +1,26 @@
 import { api } from "../api";
 
 export default async (presets: any[]) => {
+  await deleteAllPresets();
   const cleanPresets = presets.map((preset) => {
     preset.user = null;
-    delete preset.id;
     return preset;
   });
   try {
     await api.post("presets", cleanPresets);
   } catch (error) {
     console.log("Error uploading preset", error.response.data.errors);
+  }
+};
+
+const deleteAllPresets = async () => {
+  try {
+    const { data: presets } = await api.get<any>("presets");
+    const ids = presets.data.map((preset) => preset.id);
+    await api.delete("presets", {
+      data: ids,
+    });
+  } catch (error) {
+    console.log("Error removing existing presets", error.response.data.errors);
   }
 };


### PR DESCRIPTION
cleaner approach to my previous fix.

The issue starts because presets are created while the admin logs in and creates a static token.

This update adds an additional function which removes all exsting presets before loading the template.