### PR TITLE
fix: add project color for the website template project settings

### DIFF
--- a/templates/website/src/settings.json
+++ b/templates/website/src/settings.json
@@ -2,7 +2,7 @@
   "id": 1,
   "project_name": "Directus",
   "project_url": null,
-  "project_color": null,
+  "project_color": "#6644FF",
   "project_logo": null,
   "public_foreground": null,
   "public_background": null,


### PR DESCRIPTION
I noticed an error while applying the website template:

```
Error loading settings [
  {
    message: `Validation failed for field "project_color". Value can't be null.`,
    extensions: {
      code: 'FAILED_VALIDATION',
      field: 'project_color',
      type: 'nnull'
    }
  }
```
Looking at the `Agency OS` template I made the assumption that it would be better to define a value here, so I have set it to the default Directus color. Tested locally, the import error is gone (works on my machine).
