### PR TITLE
[feat] add flags to limit extraction

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json.schemastore.org/prettierrc",
+  "semi": false,
+  "tabWidth": 2,
+  "singleQuote": true,
+  "printWidth": 100,
+  "trailingComma": "es5",
+  "importOrderSeparation": true,
+  "importOrderSortSpecifiers": true,
+  "bracketSameLine": false,
+  "htmlWhitespaceSensitivity": "ignore"
+}

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 A streamlined CLI tool for creating new Directus projects and managing Directus templates - making it easy to apply and extract template configurations across instances.
 
 This tool is best suited for:
+
 - Proof of Concept (POC) projects
 - Demo environments
 - New project setups
@@ -10,8 +11,9 @@ This tool is best suited for:
 ⚠️ We strongly recommend against using this tool in existing production environments or as a critical part of your CI/CD pipeline without thorough testing. Always create backups before applying templates.
 
 **Important Notes:**
+
 - **Primary Purpose**: Built to deploy templates created by the Directus Core Team. While community templates are supported, the unlimited possible configurations make comprehensive support challenging.
-- **Database Compatibility**: PostgreSQL is recommended. Applying templates that are extracted and applied between different databases (Extract from SQLite ->  Apply to Postgres) can caused issues and is not recommended. MySQL users may encounter known issues.
+- **Database Compatibility**: PostgreSQL is recommended. Applying templates that are extracted and applied between different databases (Extract from SQLite -> Apply to Postgres) can caused issues and is not recommended. MySQL users may encounter known issues.
 - **Performance**: Remote operations (extract/apply) are rate-limited to 10 requests/second using bottleneck. Processing time varies based on your instance size (collections, items, assets).
 - **Version Compatibility**:
   - v0.5.0+: Compatible with Directus 11 and up
@@ -30,6 +32,7 @@ npx directus-template-cli@latest init
 ```
 
 You'll be guided through:
+
 - Selecting a directory for your new project
 - Choosing a Directus backend template
 - Selecting a frontend framework (if available for the template)
@@ -50,7 +53,6 @@ npx directus-template-cli@latest init --frontend=nextjs --template=cms
 npx directus-template-cli@latest init my-project --frontend=nextjs --template=cms
 npx directus-template-cli@latest init --template=https://github.com/directus-labs/starters/tree/main/cms
 ```
-
 
 Available flags:
 
@@ -112,6 +114,7 @@ The `directus:template` property contains:
   - Each frontend has a `name` (display name) and `path` (directory containing the frontend code)
 
 When you use this template with the `init` command, it will:
+
 1. Copy the Directus template files from the specified template directory
 2. Copy the selected frontend code based on your choice or the `--frontend` flag
 3. Set up the project structure with both backend and frontend integrated
@@ -133,11 +136,9 @@ npx directus-template-cli@latest apply
 
 You can choose from our community maintained templates or you can also choose a template from a local directory or a public GitHub repository.
 
-
 ### Programmatic Mode
 
 By default, the CLI will run in interactive mode. For CI/CD pipelines or automated scripts, you can use the programmatic mode:
-
 
 Using a token:
 
@@ -196,7 +197,6 @@ This command will apply the template but exclude content and users. Available `-
 - `--no-settings`: Skip loading Settings
 - `--no-users`: Skip loading Users
 
-
 #### Template Component Dependencies
 
 When applying templates, certain components have dependencies on others. Here are the key relationships to be aware of:
@@ -230,7 +230,6 @@ You can also pass flags as environment variables. This can be useful for CI/CD p
 - `TARGET_DIRECTUS_PASSWORD`: Equivalent to `--userPassword`
 - `TEMPLATE_LOCATION`: Equivalent to `--templateLocation`
 - `TEMPLATE_TYPE`: Equivalent to `--templateType`
-
 
 ### Existing Data
 
@@ -290,6 +289,10 @@ Available flags:
 - `--templateLocation`: Directory to extract the template to (required)
 - `--templateName`: Name of the template (required)
 - `--disableTelemetry`: Disable telemetry collection
+- `--skipCollectionFiles`: Do not extract the directus_files collection
+- `--skipDownloadFiles`: Do not download the actual file attachments
+- `--syncExtractContent`: Extract content collections in a serial manner to limit load on instance
+- `--limitContentCollections "collectionA,collectionB"`: Only extract named content collections from comma-separated list
 
 #### Using Environment Variables
 
@@ -306,9 +309,10 @@ Similar to the Apply command, you can use environment variables for the Extract 
 The Directus Template CLI logs information to a file in the `.directus-template-cli/logs` directory.
 
 Logs are automatically generated for each run of the CLI. Here's how the logging system works:
-   - A new log file is created for each CLI run.
-   - Log files are stored in the `.directus-template-cli/logs` directory within your current working directory.
-   - Each log file is named `run-[timestamp].log`, where `[timestamp]` is the ISO timestamp of when the CLI was initiated.
+
+- A new log file is created for each CLI run.
+- Log files are stored in the `.directus-template-cli/logs` directory within your current working directory.
+- Each log file is named `run-[timestamp].log`, where `[timestamp]` is the ISO timestamp of when the CLI was initiated.
 
 The logger automatically sanitizes sensitive information such as passwords, tokens, and keys before writing to the log file. But it may not catch everything. Just be aware of this and make sure to remove the log files when they are no longer needed.
 

--- a/package.json
+++ b/package.json
@@ -79,7 +79,8 @@
     "prepack": "pnpm run build && oclif manifest && oclif readme",
     "test": "mocha --forbid-only \"test/**/*.test.ts\"",
     "version": "oclif readme && git add README.md",
-    "run": "./bin/run.js"
+    "run": "./bin/run.js",
+    "run:dev": "./bin/dev.js"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/src/flags/common.ts
+++ b/src/flags/common.ts
@@ -1,4 +1,4 @@
-import {Flags} from '@oclif/core'
+import { Flags } from '@oclif/core'
 
 export const directusToken = Flags.string({
   description: 'Token to use for the Directus instance',
@@ -48,4 +48,27 @@ export const disableTelemetry = Flags.boolean({
   default: false,
   description: 'Disable telemetry',
   env: 'DISABLE_TELEMETRY',
+})
+
+export const skipCollectionFiles = Flags.boolean({
+  default: false,
+  description: 'Skip extracting collection "directus_files"',
+  env: 'SKIP_COLLECTION_FILES',
+})
+
+export const skipDownloadFiles = Flags.boolean({
+  default: false,
+  description: 'Skip downloading asset files',
+  env: 'SKIP_DOWNLOAD_FILES',
+})
+
+export const syncExtractContent = Flags.boolean({
+  default: false,
+  description: 'Fetch content collections synchronously to reduce load on the Directus instance',
+  env: 'SYNC_EXTRACT_CONTENT',
+})
+
+export const limitContentCollections = Flags.string({
+  description: 'Limit content extraction to specific collections (comma-separated)',
+  env: 'LIMIT_CONTENT_COLLECTIONS',
 })

--- a/src/lib/extract/extract-content.ts
+++ b/src/lib/extract/extract-content.ts
@@ -1,33 +1,57 @@
-import {readCollections, readItems} from '@directus/sdk'
-import {ux} from '@oclif/core'
+import { readCollections, readItems } from '@directus/sdk'
+import { ux } from '@oclif/core'
 
-import {DIRECTUS_PINK} from '../constants.js'
-import {api} from '../sdk.js'
+import { DIRECTUS_PINK, DIRECTUS_PURPLE } from '../constants.js'
+import { api } from '../sdk.js'
 import catchError from '../utils/catch-error.js'
 import writeToFile from '../utils/write-to-file.js'
+import { ExtractFlags } from '../../commands/extract.js'
 
-async function getCollections() {
+async function getCollections(limitedCollections?: string) {
   const response = await api.client.request(readCollections())
   return response
-  .filter(item => !item.collection.startsWith('directus_', 0))
-  .filter(item => item.schema != null)
-  .map(i => i.collection)
+    .filter((item) => !item.collection.startsWith('directus_', 0))
+    .filter((item) => item.schema != null)
+    .map((i) => i.collection)
+    .filter((collection) => {
+      if (!limitedCollections) return true
+      return limitedCollections
+        .split(',')
+        .map((c) => c.trim())
+        .includes(collection)
+    })
 }
 
-async function getDataFromCollection(collection: string, dir: string) {
+async function getDataFromCollection(collection: string, dir: string, flags: ExtractFlags) {
   try {
-    const response = await api.client.request(readItems(collection as never, {limit: -1}))
+    if (flags.syncExtractContent)
+      ux.action.start(
+        ux.colorize(DIRECTUS_PURPLE, `-- Fetching data from collection: ${collection}`)
+      )
+    const response = await api.client.request(readItems(collection as never, { limit: -1 }))
     await writeToFile(`${collection}`, response, `${dir}/content/`)
+    if (flags.syncExtractContent) ux.action.stop('...done')
   } catch (error) {
     catchError(error)
   }
 }
 
-export async function extractContent(dir: string) {
+export async function extractContent(dir: string, flags: ExtractFlags) {
   ux.action.start(ux.colorize(DIRECTUS_PINK, 'Extracting content'))
   try {
-    const collections = await getCollections()
-    await Promise.all(collections.map(collection => getDataFromCollection(collection, dir)))
+    const collections = await getCollections(flags.limitContentCollections)
+    if (flags.syncExtractContent) {
+      ux.stdout(ux.colorize(DIRECTUS_PURPLE, `- Limited to collections: ${collections.join(', ')}`))
+      // Fetch collections one by one to reduce load on the Directus instance
+      for (let i = 0; i < collections.length; i++) {
+        const collection = collections[i]
+        await getDataFromCollection(collection, dir, flags)
+      }
+    } else {
+      await Promise.all(
+        collections.map((collection) => getDataFromCollection(collection, dir, flags))
+      )
+    }
   } catch (error) {
     catchError(error)
   }

--- a/src/lib/extract/index.ts
+++ b/src/lib/extract/index.ts
@@ -1,15 +1,15 @@
-import {ux} from '@oclif/core'
+import { ux } from '@oclif/core'
 import fs from 'node:fs'
 
 import extractAccess from './extract-access.js'
-import {downloadAllFiles} from './extract-assets.js'
+import { downloadAllFiles } from './extract-assets.js'
 import extractCollections from './extract-collections.js'
-import {extractContent} from './extract-content.js'
-import {extractDashboards, extractPanels} from './extract-dashboards.js'
+import { extractContent } from './extract-content.js'
+import { extractDashboards, extractPanels } from './extract-dashboards.js'
 import extractExtensions from './extract-extensions.js'
 import extractFields from './extract-fields.js'
 import extractFiles from './extract-files.js'
-import {extractFlows, extractOperations} from './extract-flows.js'
+import { extractFlows, extractOperations } from './extract-flows.js'
 import extractFolders from './extract-folders.js'
 import extractPermissions from './extract-permissions.js'
 import extractPolicies from './extract-policies.js'
@@ -20,15 +20,17 @@ import extractSchema from './extract-schema.js'
 import extractSettings from './extract-settings.js'
 import extractTranslations from './extract-translations.js'
 import extractUsers from './extract-users.js'
+import { ExtractFlags } from '../../commands/extract.js'
+import { DIRECTUS_PURPLE } from '../constants.js'
 
-export default async function extract(dir: string) {
+export default async function extract(dir: string, flags: ExtractFlags) {
   // Get the destination directory for the actual files
   const destination = `${dir}/src`
 
   // Check if directory exists, if not, then create it.
   if (!fs.existsSync(destination)) {
     ux.stdout(`Attempting to create directory at: ${destination}`)
-    fs.mkdirSync(destination, {recursive: true})
+    fs.mkdirSync(destination, { recursive: true })
   }
 
   await extractSchema(destination)
@@ -38,7 +40,14 @@ export default async function extract(dir: string) {
   await extractRelations(destination)
 
   await extractFolders(destination)
-  await extractFiles(destination)
+  if (!flags.skipCollectionFiles) await extractFiles(destination)
+  else
+    ux.stdout(
+      ux.colorize(
+        DIRECTUS_PURPLE,
+        '- Skipping extraction of collection directus_files (--skipCollectionFiles)'
+      )
+    )
 
   await extractUsers(destination)
   await extractRoles(destination)
@@ -59,9 +68,10 @@ export default async function extract(dir: string) {
   await extractSettings(destination)
   await extractExtensions(destination)
 
-  await extractContent(destination)
+  await extractContent(destination, flags)
 
-  await downloadAllFiles(destination)
+  if (!flags.skipDownloadFiles) await downloadAllFiles(destination)
+  else ux.stdout(ux.colorize(DIRECTUS_PURPLE, '- Skipping download of files (--skipDownloadFiles)'))
 
   return {}
 }

--- a/src/lib/utils/read-templates.ts
+++ b/src/lib/utils/read-templates.ts
@@ -2,13 +2,11 @@ import fs from 'node:fs'
 import path from 'pathe'
 
 interface Template {
-  directoryPath: string;
-  templateName: string;
+  directoryPath: string
+  templateName: string
 }
 
-export async function readTemplate(
-  directoryPath: string,
-): Promise<Template | null> {
+export async function readTemplate(directoryPath: string): Promise<Template | null> {
   const packageFilePath = path.join(directoryPath, 'package.json')
 
   try {
@@ -31,9 +29,7 @@ export async function readTemplate(
   }
 }
 
-export async function readAllTemplates(
-  directoryPath: string,
-): Promise<Template[]> {
+export async function readAllTemplates(directoryPath: string): Promise<Template[]> {
   const templates: Template[] = []
 
   const files = await fs.promises.readdir(directoryPath)


### PR DESCRIPTION
This PR adds a number of flags to the `extract` command.

- `--skipCollectionFiles`: do not extract the `directus_files` collection
-  `--skipDownloadFiles`: do not download the actual file attachments 
- `--syncExtractContent`: extract content collections in a serial manner to limit load on instance 
- `--limitContentCollections "articles,something_else"`: only extract named content collections

## Motivation

We have a few very underpowered instances running Directus in a Kubernetes context, with a limit on CPU usage. Some of these have large collections, for example large amounts of image files. Running the template extract will cause the CPU load on these instances to spike over a long time, causing them to crash eventually (either by running out of RAM or by being forcibly stopped by Kubernetes).

To make the template CLI usable without crashing the instances, we had to disable all file related extractions. Thus, these added flags.

## Possible Issues

By selectively extracting collections or files, there is a real danger of breaking relations if other collections point to these missing entries. Managing these issues is the responsibility of the user - since these flags are only to be used in specific use cases, it is assumed that the user knows what he or she does...

Edit: just noticed that a similar PR exists. Oh well...