### PR TITLE
Bugfix: Exit on programmatic apply

### DIFF
--- a/src/commands/apply.ts
+++ b/src/commands/apply.ts
@@ -336,7 +336,8 @@ export default class ApplyCommand extends BaseCommand {
     // log.warn(BSL_LICENSE_HEADLINE)
     // log.info(BSL_LICENSE_TEXT)
     // log.info(BSL_LICENSE_CTA)
-    // ux.exit(0)
+
+    ux.exit(0)
   }
 
   /**


### PR DESCRIPTION
This PR closes #99, which reports that the cli process fails to exit when applying a template. This is true when running in programmatic mode.

The root cause is that the last commit ([#aa0dda7](https://github.com/directus-labs/directus-template-cli/commit/aa0dda73406855a293702d0c528ff49f94a7ca4f), #83) removed the `ux.exit(0)` call after the `'Template applied successfully.'` log message within the `runProgrammatic` function — well, in fact, the line was commented out rather than deleted.

For reference, `runInteractive` ends with

```js
      log.warn(BSL_LICENSE_HEADLINE)
      log.info(BSL_LICENSE_TEXT)
      log.info(BSL_LICENSE_CTA)

      ux.stdout('Template applied successfully.')
      ux.exit(0)
```

Whereas `runProgrammatic` ends with

```js
    ux.stdout('Template applied successfully.')

    // Hide BSL license info if running programatically for now
    // log.warn(BSL_LICENSE_HEADLINE)
    // log.info(BSL_LICENSE_TEXT)
    // log.info(BSL_LICENSE_CTA)
    // ux.exit(0)
 ```

Before the change, `runProgrammatic` ended with

```js
    ux.info('Template applied successfully.')
    ux.exit(0)
```

It seems more than likely that commenting out `ux.exit(0)` was unintentional while updating the console logs. Maybe @bryantgillespie, who did that change, could take a quick look and potentially merge this and release a fixed version to restore the proper exit behavior in CI environments. 🤞