### PR TITLE
feat: add partial extraction support

### DIFF
--- a/src/lib/extract/extract-flags.ts
+++ b/src/lib/extract/extract-flags.ts
@@ -1,0 +1,65 @@
+import {ux} from '@oclif/core'
+
+export interface ExtractOptions {
+  content: boolean;
+  dashboards: boolean;
+  extensions: boolean;
+  files: boolean;
+  flows: boolean;
+  permissions: boolean;
+  schema: boolean;
+  settings: boolean;
+  users: boolean;
+}
+
+export interface ExtractFlags extends ExtractOptions {
+  directusToken: string;
+  directusUrl: string;
+  disableTelemetry?: boolean;
+  partial?: boolean;
+  programmatic: boolean;
+  templateLocation: string;
+  templateName: string;
+  userEmail: string;
+  userPassword: string;
+}
+
+export const extractFlags = [
+  'content',
+  'dashboards',
+  'extensions',
+  'files',
+  'flows',
+  'permissions',
+  'schema',
+  'settings',
+  'users',
+] as const
+
+export function validateExtractFlags(flags: ExtractFlags): ExtractFlags {
+  return flags.partial ? handlePartialFlags(flags) : setAllFlagsTrue(flags)
+}
+
+function handlePartialFlags(flags: ExtractFlags): ExtractFlags {
+  const enabledFlags = extractFlags.filter(flag => flags[flag] === true)
+  const disabledFlags = extractFlags.filter(flag => flags[flag] === false)
+
+  if (enabledFlags.length > 0) {
+    for (const flag of extractFlags) flags[flag] = enabledFlags.includes(flag)
+  } else if (disabledFlags.length > 0) {
+    for (const flag of extractFlags) flags[flag] = !disabledFlags.includes(flag)
+  } else {
+    setAllFlagsTrue(flags)
+  }
+
+  if (!extractFlags.some(flag => flags[flag])) {
+    ux.error('When using --partial, at least one component must be extracted.')
+  }
+
+  return flags
+}
+
+function setAllFlagsTrue(flags: ExtractFlags): ExtractFlags {
+  for (const flag of extractFlags) flags[flag] = true
+  return flags
+}

--- a/src/lib/extract/index.ts
+++ b/src/lib/extract/index.ts
@@ -1,6 +1,8 @@
 import {ux} from '@oclif/core'
 import fs from 'node:fs'
 
+import type {ExtractFlags} from './extract-flags.js'
+
 import extractAccess from './extract-access.js'
 import {downloadAllFiles} from './extract-assets.js'
 import extractCollections from './extract-collections.js'
@@ -21,7 +23,7 @@ import extractSettings from './extract-settings.js'
 import extractTranslations from './extract-translations.js'
 import extractUsers from './extract-users.js'
 
-export default async function extract(dir: string) {
+export default async function extract(dir: string, flags?: ExtractFlags) {
   // Get the destination directory for the actual files
   const destination = `${dir}/src`
 
@@ -31,37 +33,66 @@ export default async function extract(dir: string) {
     fs.mkdirSync(destination, {recursive: true})
   }
 
-  await extractSchema(destination)
+  // Schema extraction (collections, fields, relations)
+  if (!flags || flags.schema) {
+    await extractSchema(destination)
+    await extractCollections(destination)
+    await extractFields(destination)
+    await extractRelations(destination)
+  }
 
-  await extractCollections(destination)
-  await extractFields(destination)
-  await extractRelations(destination)
+  // Files extraction (folders, files metadata)
+  if (!flags || flags.files) {
+    await extractFolders(destination)
+    await extractFiles(destination)
+  }
 
-  await extractFolders(destination)
-  await extractFiles(destination)
+  // Permissions extraction (users, roles, permissions, policies, access)
+  if (!flags || flags.permissions) {
+    await extractRoles(destination)
+    await extractPermissions(destination)
+    await extractPolicies(destination)
+    await extractAccess(destination)
+  }
 
-  await extractUsers(destination)
-  await extractRoles(destination)
-  await extractPermissions(destination)
-  await extractPolicies(destination)
-  await extractAccess(destination)
+  // Users extraction
+  if (!flags || flags.users) {
+    await extractUsers(destination)
+  }
 
-  await extractPresets(destination)
+  // Settings extraction (presets, translations, settings)
+  if (!flags || flags.settings) {
+    await extractPresets(destination)
+    await extractTranslations(destination)
+    await extractSettings(destination)
+  }
 
-  await extractTranslations(destination)
+  // Flows extraction (flows, operations)
+  if (!flags || flags.flows) {
+    await extractFlows(destination)
+    await extractOperations(destination)
+  }
 
-  await extractFlows(destination)
-  await extractOperations(destination)
+  // Dashboards extraction (dashboards, panels)
+  if (!flags || flags.dashboards) {
+    await extractDashboards(destination)
+    await extractPanels(destination)
+  }
 
-  await extractDashboards(destination)
-  await extractPanels(destination)
+  // Extensions extraction
+  if (!flags || flags.extensions) {
+    await extractExtensions(destination)
+  }
 
-  await extractSettings(destination)
-  await extractExtensions(destination)
+  // Content extraction (data)
+  if (!flags || flags.content) {
+    await extractContent(destination)
+  }
 
-  await extractContent(destination)
-
-  await downloadAllFiles(destination)
+  // Download files (only if files extraction is enabled)
+  if (!flags || flags.files) {
+    await downloadAllFiles(destination)
+  }
 
   return {}
 }


### PR DESCRIPTION
Adds --partial flag with component selection for programmatic extraction:

Extract only schema (no content, users, etc.)
 `directus-template-cli extract -p --partial --no-content --no-users`

Extract only specific components
`directus-template-cli extract -p --partial --schema --permissions`

New flags:
  --partial          Enable partial extraction mode
  --[no-]schema      Extract schema (collections, fields, relations)
  --[no-]content     Extract content data
  --[no-]files       Extract files and folders
  --[no-]flows       Extract flows and operations
  --[no-]dashboards  Extract dashboards and panels
  --[no-]permissions Extract permissions (roles, policies, access)
  --[no-]settings    Extract settings, translations, presets
  --[no-]extensions  Extract extensions
  --[no-]users       Extract users

When --partial is used:
- If any --<component> flag is set, only those components are extracted
- If any --no-<component> flag is set, all except those are extracted
- At least one component must be selected