### PR TITLE
[Monorepo Merge] Point COMMUNITY_TEMPLATE_REPO to directus-labs/starters

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -7,8 +7,8 @@ export const pinkText = chalk.hex(DIRECTUS_PINK)
 export const purpleText = chalk.hex(DIRECTUS_PURPLE)
 
 export const COMMUNITY_TEMPLATE_REPO = {
-  string: 'github:directus-labs/directus-templates',
-  url: 'https://github.com/directus-labs/directus-templates',
+  string: 'github:directus-labs/starters',
+  url: 'https://github.com/directus-labs/starters',
 }
 
 export const DEFAULT_REPO = {


### PR DESCRIPTION
## Summary
- Update `COMMUNITY_TEMPLATE_REPO` constant to point to `directus-labs/starters` instead of `directus-labs/directus-templates`
- The `directus-templates` repo has been merged into `starters` (see directus-labs/starters#new-pr)
- `DEFAULT_REPO` already pointed to `starters`, so only `COMMUNITY_TEMPLATE_REPO` needed updating

## Test plan
- [ ] Run `npx directus-template-cli apply` and verify templates are fetched from `directus-labs/starters`
- [ ] Run `npx directus-template-cli init` and verify template list includes all templates