### PR TITLE
fix: use native FormData instead of formdata-node polyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "defu": "^6.1.4",
     "dotenv": "^16.4.7",
     "execa": "9.5.2",
-    "formdata-node": "^6.0.3",
     "giget": "^2.0.0",
     "glob": "^11.0.1",
     "log-update": "^6.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,9 +49,6 @@ importers:
       execa:
         specifier: 9.5.2
         version: 9.5.2
-      formdata-node:
-        specifier: ^6.0.3
-        version: 6.0.3
       giget:
         specifier: ^2.0.0
         version: 2.0.0
@@ -2522,11 +2519,6 @@ packages:
     resolution:
       {integrity: sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==}
     engines: {node: '>= 6'}
-
-  formdata-node@6.0.3:
-    resolution:
-      {integrity: sha512-8e1++BCiTzUno9v5IZ2J6bv4RU+3UKDmqWUQD0MIMVCd9AdhWkO1gw57oo1mNEX1dMq2EGI+FbWz4B92pscSQg==}
-    engines: {node: '>= 18'}
 
   fs-extra@8.1.0:
     resolution:
@@ -7171,8 +7163,6 @@ snapshots:
       combined-stream: 1.0.8
       es-set-tostringtag: 2.1.0
       mime-types: 2.1.35
-
-  formdata-node@6.0.3: {}
 
   fs-extra@8.1.0:
     dependencies:

--- a/src/lib/load/load-files.ts
+++ b/src/lib/load/load-files.ts
@@ -1,6 +1,5 @@
 import { readFiles, uploadFiles } from '@directus/sdk'
 import { ux } from '@oclif/core'
-import { FormData } from 'formdata-node'
 import { readFileSync } from 'node:fs'
 import path from 'pathe'
 


### PR DESCRIPTION
## Summary

- Removes `formdata-node` polyfill in favor of native `FormData` (available since Node 18)
- Fixes file upload failures (`"type" is required` errors) on Node 22+

## Problem

`formdata-node`'s `FormData` class is not recognized by Node's native `fetch`. When passed as a request body, it serializes as `"[object FormData]"` instead of proper multipart data. Directus receives a broken body with no fields and rejects with `Invalid payload. "type" is required.`

## Test plan

- [ ] Apply a template with files on Node 22+
- [ ] Verify file uploads succeed without `"type" is required` errors