### PR TITLE
fix: handle GitHub monorepo URLs in apply flow

### DIFF
--- a/src/commands/apply.ts
+++ b/src/commands/apply.ts
@@ -10,7 +10,7 @@ import apply from '../lib/load/index.js'
 import {animatedBunny} from '../lib/utils/animated-bunny.js'
 import {getDirectusEmailAndPassword, getDirectusToken, getDirectusUrl, initializeDirectusApi} from '../lib/utils/auth.js'
 import catchError from '../lib/utils/catch-error.js'
-import {getCommunityTemplates, getGithubTemplate, getInteractiveLocalTemplate, getLocalTemplate} from '../lib/utils/get-template.js'
+import {getCommunityTemplates, getGithubTemplate, getInteractiveGithubTemplate, getInteractiveLocalTemplate, getLocalTemplate} from '../lib/utils/get-template.js'
 import {logger} from '../lib/utils/logger.js'
 import openUrl from '../lib/utils/open-url.js'
 import { shutdown, track } from '../services/posthog.js'
@@ -153,7 +153,7 @@ static flags = {
       const ghTemplateUrl = await text({
         message: 'What is the public GitHub repository URL?',
       })
-      template = await getGithubTemplate(ghTemplateUrl as string)
+      template = await this.selectGithubTemplate(ghTemplateUrl as string)
       break
     }
 
@@ -349,6 +349,29 @@ static flags = {
    * @param localTemplateDir - The local template directory path
    * @returns {Promise<Template>} - Returns the selected template
    */
+  private async selectGithubTemplate(ghTemplateUrl: string): Promise<Template> {
+    try {
+      const templates = await getInteractiveGithubTemplate(ghTemplateUrl)
+
+      if (templates.length === 1) {
+        return templates[0]
+      }
+
+      log.info('Multiple Directus templates found in this repository.')
+      const selectedTemplate = await select({
+        message: 'Select a template.',
+        options: templates.map(t => ({label: t.templateName, value: t})),
+      })
+      return selectedTemplate as Template
+    } catch (error) {
+      if (error instanceof Error) {
+        ux.error(error.message)
+      } else {
+        ux.error('An unknown error occurred while getting the GitHub template.')
+      }
+    }
+  }
+
   private async selectLocalTemplate(localTemplateDir: string): Promise<Template> {
     try {
       const templates = await getInteractiveLocalTemplate(localTemplateDir)

--- a/src/commands/apply.ts
+++ b/src/commands/apply.ts
@@ -345,8 +345,8 @@ static flags = {
 
   /**
    * INTERACTIVE
-   * Select a local template from the given directory
-   * @param localTemplateDir - The local template directory path
+   * Select a template from the given GitHub repository
+   * @param ghTemplateUrl - The GitHub repository URL
    * @returns {Promise<Template>} - Returns the selected template
    */
   private async selectGithubTemplate(ghTemplateUrl: string): Promise<Template> {
@@ -369,6 +369,8 @@ static flags = {
       } else {
         ux.error('An unknown error occurred while getting the GitHub template.')
       }
+
+      throw error
     }
   }
 
@@ -394,6 +396,8 @@ static flags = {
       } else {
         ux.error('An unknown error occurred while getting the local template.')
       }
+
+      throw error
     }
   }
 }

--- a/src/lib/utils/get-template.ts
+++ b/src/lib/utils/get-template.ts
@@ -4,9 +4,10 @@ import {fileURLToPath} from 'node:url'
 import path, {dirname} from 'pathe'
 
 import {COMMUNITY_TEMPLATE_REPO} from '../constants.js'
+import {logger} from './logger.js'
 import resolvePathAndCheckExistence from './path.js'
 import {readAllTemplates, readTemplate} from './read-templates.js'
-import {transformGitHubUrl} from './transform-github-url.js'
+import {parseGitHubUrl, transformGitHubUrl} from './transform-github-url.js'
 
 // Create __dirname equivalent for ESM
 const __filename = fileURLToPath(import.meta.url)
@@ -97,27 +98,93 @@ async function findNestedTemplates(dir: string, depth: number): Promise<Template
   return templates
 }
 
+async function downloadGithubTemplate(ghTemplateUrl: string): Promise<string> {
+  const ghString = transformGitHubUrl(ghTemplateUrl)
+  const downloadDir = resolvePathAndCheckExistence(path.join(__dirname, '..', 'downloads', 'github'), false)
+
+  if (!downloadDir) {
+    throw new Error(`Invalid download directory: ${path.join(__dirname, '..', 'downloads', 'github')}`)
+  }
+
+  const {dir} = await downloadTemplate(ghString, {
+    dir: downloadDir,
+    force: true,
+    forceClean: true,
+  })
+
+  const resolvedDir = resolvePathAndCheckExistence(dir)
+  if (!resolvedDir) {
+    throw new Error(`Downloaded template directory does not exist: ${dir}`)
+  }
+
+  return resolvedDir
+}
+
+function buildSubpathUrl(ghTemplateUrl: string, templatePath: string): string {
+  const {owner, ref, repo} = parseGitHubUrl(ghTemplateUrl)
+  const normalizedPath = templatePath.split(path.sep).join('/')
+  return `https://github.com/${owner}/${repo}/tree/${ref || 'main'}/${normalizedPath}`
+}
+
 export async function getGithubTemplate(ghTemplateUrl: string): Promise<Template> {
   try {
-    const ghString = await transformGitHubUrl(ghTemplateUrl)
-    const downloadDir = resolvePathAndCheckExistence(path.join(__dirname, '..', 'downloads', 'github'), false)
+    const resolvedDir = await downloadGithubTemplate(ghTemplateUrl)
 
-    if (!downloadDir) {
-      throw new Error(`Invalid download directory: ${path.join(__dirname, '..', 'downloads', 'github')}`)
+    const template = await readTemplate(resolvedDir)
+    if (template) {
+      return template
     }
 
-    const {dir} = await downloadTemplate(ghString, {
-      dir: downloadDir,
-      force: true,
-      forceClean: true,
-    })
+    const nested = await findNestedTemplates(resolvedDir, 3)
 
-    const resolvedDir = resolvePathAndCheckExistence(dir)
-    if (!resolvedDir) {
-      throw new Error(`Downloaded template directory does not exist: ${dir}`)
+    if (nested.length === 1) {
+      const subpath = path.relative(resolvedDir, nested[0].directoryPath)
+      const pinnedUrl = buildSubpathUrl(ghTemplateUrl, subpath)
+      logger.log(
+        'warn',
+        `Auto-selected nested template "${nested[0].templateName}" at ${subpath}. Pin --templateLocation="${pinnedUrl}" to avoid ambiguity if more templates are added.`,
+      )
+      return nested[0]
     }
 
-    return readTemplate(resolvedDir)
+    if (nested.length > 1) {
+      const list = nested
+        .map(t => {
+          const subpath = path.relative(resolvedDir, t.directoryPath)
+          return `  --templateLocation="${buildSubpathUrl(ghTemplateUrl, subpath)}"   # ${t.templateName}`
+        })
+        .join('\n')
+      throw new Error(
+        `Found multiple Directus templates in ${ghTemplateUrl}. Re-run with one of:\n${list}`,
+      )
+    }
+
+    throw new Error(
+      `No Directus template found at ${ghTemplateUrl}. A Directus template needs a package.json with a "templateName" field.`,
+    )
+  } catch (error) {
+    throw new Error(`Failed to download GitHub template: ${error}`)
+  }
+}
+
+export async function getInteractiveGithubTemplate(ghTemplateUrl: string): Promise<Template[]> {
+  try {
+    const resolvedDir = await downloadGithubTemplate(ghTemplateUrl)
+
+    const template = await readTemplate(resolvedDir)
+    if (template) {
+      return [template]
+    }
+
+    const nested = await findNestedTemplates(resolvedDir, 3)
+
+    if (nested.length === 0) {
+      throw new Error(
+        `No Directus template found at ${ghTemplateUrl}. A Directus template needs a package.json with a "templateName" field.`,
+      )
+    }
+
+    return nested
   } catch (error) {
     throw new Error(`Failed to download GitHub template: ${error}`)
   }

--- a/src/lib/utils/get-template.ts
+++ b/src/lib/utils/get-template.ts
@@ -123,7 +123,11 @@ async function downloadGithubTemplate(ghTemplateUrl: string): Promise<string> {
 function buildSubpathUrl(ghTemplateUrl: string, templatePath: string): string {
   const {owner, ref, repo} = parseGitHubUrl(ghTemplateUrl)
   const normalizedPath = templatePath.split(path.sep).join('/')
-  return `https://github.com/${owner}/${repo}/tree/${ref || 'main'}/${normalizedPath}`
+  return `https://github.com/${owner}/${repo}/tree/${ref || 'HEAD'}/${normalizedPath}`
+}
+
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
 }
 
 export async function getGithubTemplate(ghTemplateUrl: string): Promise<Template> {
@@ -163,7 +167,7 @@ export async function getGithubTemplate(ghTemplateUrl: string): Promise<Template
       `No Directus template found at ${ghTemplateUrl}. A Directus template needs a package.json with a "templateName" field.`,
     )
   } catch (error) {
-    throw new Error(`Failed to download GitHub template: ${error}`)
+    throw new Error(`Failed to download GitHub template: ${getErrorMessage(error)}`, {cause: error})
   }
 }
 
@@ -186,6 +190,6 @@ export async function getInteractiveGithubTemplate(ghTemplateUrl: string): Promi
 
     return nested
   } catch (error) {
-    throw new Error(`Failed to download GitHub template: ${error}`)
+    throw new Error(`Failed to download GitHub template: ${getErrorMessage(error)}`, {cause: error})
   }
 }

--- a/src/lib/utils/transform-github-url.ts
+++ b/src/lib/utils/transform-github-url.ts
@@ -1,13 +1,26 @@
-export function transformGitHubUrl(url: string): string {
-  // Regular expression to capture the repository name and any subsequent path after the 'tree'
-  const regex = /github\.com\/([^/]+\/[^/]+)(?:\/tree\/[^/]+\/(.*))?$/
-  const match = url.match(regex)
+export interface ParsedGitHubUrl {
+  owner: string
+  ref?: string
+  repo: string
+  subpath?: string
+}
 
-  if (match) {
-    const repo = match[1]
-    const subpath = match[2] ? match[2] : ''
-    return `github:${repo}/${subpath}`
+export function parseGitHubUrl(url: string): ParsedGitHubUrl {
+  const cleaned = url.trim().replace(/\.git$/, '').replace(/\/+$/, '')
+  const regex = /github\.com\/([^/]+)\/([^/]+)(?:\/tree\/([^/]+)(?:\/(.+))?)?$/
+  const match = cleaned.match(regex)
+
+  if (!match) {
+    throw new Error(`Invalid GitHub URL: ${url}`)
   }
 
-  return 'Invalid URL'
+  const [, owner, repo, ref, subpath] = match
+  return {owner, ref, repo, subpath}
+}
+
+export function transformGitHubUrl(url: string): string {
+  const {owner, ref, repo, subpath} = parseGitHubUrl(url)
+  const pathPart = subpath ? `/${subpath}` : ''
+  const refPart = ref ? `#${ref}` : ''
+  return `github:${owner}/${repo}${pathPart}${refPart}`
 }

--- a/src/lib/utils/transform-github-url.ts
+++ b/src/lib/utils/transform-github-url.ts
@@ -6,15 +6,34 @@ export interface ParsedGitHubUrl {
 }
 
 export function parseGitHubUrl(url: string): ParsedGitHubUrl {
-  const cleaned = url.trim().replace(/\.git$/, '').replace(/\/+$/, '')
-  const regex = /github\.com\/([^/]+)\/([^/]+)(?:\/tree\/([^/]+)(?:\/(.+))?)?$/
-  const match = cleaned.match(regex)
+  const cleaned = url.trim().replace(/\/+$/, '')
+  const urlToParse = /^https?:\/\//i.test(cleaned) ? cleaned : `https://${cleaned}`
+  let parsed: URL
 
-  if (!match) {
+  try {
+    parsed = new URL(urlToParse)
+  } catch {
     throw new Error(`Invalid GitHub URL: ${url}`)
   }
 
-  const [, owner, repo, ref, subpath] = match
+  if (!['github.com', 'www.github.com'].includes(parsed.hostname.toLowerCase())) {
+    throw new Error(`Invalid GitHub URL: ${url}`)
+  }
+
+  const pathParts = parsed.pathname.split('/').filter(Boolean)
+  const [owner, rawRepo, tree, ref, ...subpathParts] = pathParts
+  const repo = rawRepo?.replace(/\.git$/, '')
+
+  if (!owner || !repo || pathParts.length > 2 && tree !== 'tree') {
+    throw new Error(`Invalid GitHub URL: ${url}`)
+  }
+
+  if (tree === 'tree' && !ref) {
+    throw new Error(`Invalid GitHub URL: ${url}`)
+  }
+
+  const subpath = subpathParts.length > 0 ? subpathParts.join('/') : undefined
+
   return {owner, ref, repo, subpath}
 }
 

--- a/test/commands/apply.test.ts
+++ b/test/commands/apply.test.ts
@@ -1,5 +1,3 @@
-import {expect, test} from '@oclif/test'
-
 describe('apply', () => {
   // test
   // .stdout()

--- a/test/helpers/init.js
+++ b/test/helpers/init.js
@@ -1,4 +1,5 @@
-const path = require('node:path')
+import path from 'node:path'
+
 process.env.TS_NODE_PROJECT = path.resolve('test/tsconfig.json')
 process.env.NODE_ENV = 'development'
 

--- a/test/lib/utils/transform-github-url.test.ts
+++ b/test/lib/utils/transform-github-url.test.ts
@@ -1,0 +1,41 @@
+import {expect} from 'chai'
+
+import {parseGitHubUrl, transformGitHubUrl} from '../../../src/lib/utils/transform-github-url.js'
+
+describe('transform-github-url', () => {
+  it('parses a GitHub repository URL', () => {
+    expect(parseGitHubUrl('https://github.com/directus-labs/starters')).to.deep.equal({
+      owner: 'directus-labs',
+      ref: undefined,
+      repo: 'starters',
+      subpath: undefined,
+    })
+  })
+
+  it('parses a GitHub tree URL with a subpath', () => {
+    expect(parseGitHubUrl('github.com/directus-labs/starters/tree/main/simple-cms')).to.deep.equal({
+      owner: 'directus-labs',
+      ref: 'main',
+      repo: 'starters',
+      subpath: 'simple-cms',
+    })
+  })
+
+  it('rejects strings that only contain a GitHub URL', () => {
+    expect(() => parseGitHubUrl('foo github.com/directus-labs/starters')).to.throw(
+      'Invalid GitHub URL: foo github.com/directus-labs/starters',
+    )
+  })
+
+  it('rejects non-GitHub URLs', () => {
+    expect(() => parseGitHubUrl('https://example.com/directus-labs/starters')).to.throw(
+      'Invalid GitHub URL: https://example.com/directus-labs/starters',
+    )
+  })
+
+  it('transforms a GitHub URL into a giget string', () => {
+    expect(transformGitHubUrl('https://github.com/directus-labs/starters/tree/main/simple-cms')).to.equal(
+      'github:directus-labs/starters/simple-cms#main',
+    )
+  })
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,5 +14,6 @@
     "forceConsistentCasingInFileNames": true,
     "noImplicitAny": false
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*"],
+  "exclude": ["src/lib/downloads/**/*"]
 }


### PR DESCRIPTION
Closes #122.

## Summary

- Users entering a monorepo root URL (e.g. `https://github.com/directus-labs/starters/`) previously hit `TypeError: Cannot read properties of null (reading 'templateName')`. Now the CLI walks nested dirs and either auto-selects the single template found, prompts the user to pick when multiple exist, or errors clearly when none.
- `transformGitHubUrl` hardened: tolerates trailing slashes, `.git` suffix, preserves `/tree/<ref>/...` branch refs (previously silently discarded), throws on unparseable input instead of returning the literal string `"Invalid URL"`.
- Programmatic mode (`-p --templateType=github`) gets an actionable error listing copy-pasteable `--templateLocation="..."` URLs for each discovered template. Single-nested case auto-descends with a warning suggesting the user pin the full URL to avoid surprises if more templates are added to the repo later.

## What changed

- `src/lib/utils/transform-github-url.ts` — extracted `parseGitHubUrl` helper; hardened regex.
- `src/lib/utils/get-template.ts` — new `getInteractiveGithubTemplate` returning `Template[]`; `getGithubTemplate` now uses shared download helper and emits actionable errors.
- `src/commands/apply.ts` — new `selectGithubTemplate` method mirroring `selectLocalTemplate` pattern.

## Test plan

- [x] `pnpm tsc --noEmit` passes
- [x] Interactive `apply` against `https://github.com/directus-labs/starters/` — shows picker with CMS / CMS - i18n
- [x] Interactive `apply` against `.../tree/main/cms/directus/template` — auto-selects single template
- [x] Interactive `apply` against URL with trailing slash / `.git` — handled
- [x] Programmatic `apply -p --templateType=github --templateLocation="https://github.com/directus-labs/starters/"` — errors with copy-pasteable list
- [x] Garbage URL — clean `Invalid GitHub URL` error