### PR TITLE
delete license_key and token properties

### DIFF
--- a/src/lib/load/load-settings.ts
+++ b/src/lib/load/load-settings.ts
@@ -48,18 +48,35 @@ function mergeJsonStrings(current: string, incoming: string): string {
   }
 }
 
+/**
+ * Protected settings keys
+ */
+const PROTECTED_SETTINGS_KEYS = [
+  'license_key',
+  'license_token',
+  'ai_openai_compatible_api_key',
+  'ai_google_api_key',
+  'ai_anthropic_api_key',
+  'ai_openai_api_key',
+] as const
+
+/**
+ * Strip protected settings from the settings object
+ * @param settings - The settings object
+ * @returns The settings object with protected settings removed
+ */
+function stripProtectedSettings<T extends object>(settings: T): T {
+  const result = {...settings} as Record<string, unknown>
+  for (const key of PROTECTED_SETTINGS_KEYS) delete result[key]
+  return result as T
+}
+
 export default async function loadSettings(dir: string) {
   ux.action.start(ux.colorize(DIRECTUS_PINK, 'Loading settings'))
   const settings = readFile('settings', dir)
   try {
     const currentSettings = await api.client.request(readSettings())
-    const mergedSettings = customDefu(currentSettings as any, settings) as DirectusSettings
-
-    // @ts-ignore - ignore
-    delete mergedSettings.license_key
-    // @ts-ignore - ignore
-    delete mergedSettings.license_token
-
+    const mergedSettings = stripProtectedSettings(customDefu(currentSettings as any, settings) as DirectusSettings)
     await api.client.request(updateSettings(mergedSettings))
   } catch (error) {
     catchError(error)

--- a/src/lib/load/load-settings.ts
+++ b/src/lib/load/load-settings.ts
@@ -1,4 +1,3 @@
-
 import type {DirectusSettings} from '@directus/sdk'
 
 import {readSettings, updateSettings} from '@directus/sdk'
@@ -27,21 +26,17 @@ const customDefu = createDefu((obj, key, value) => {
 
 function mergeArrays(key: string, current: any[], incoming: any[]): any[] {
   const mergeKeys = {
-     
     basemaps: ['key'],
     custom_aspect_ratios: ['key'],
     module_bar: ['id', 'type'],
     storage_asset_presets: ['key'],
-     
   }
 
   const keys = mergeKeys[key as keyof typeof mergeKeys]
   if (!keys) return [...new Set([...current, ...incoming])]
 
   return current.concat(
-    incoming.filter(item => !current.some(
-      currentItem => keys.every(k => currentItem[k] === item[k]),
-    )),
+    incoming.filter((item) => !current.some((currentItem) => keys.every((k) => currentItem[k] === item[k]))),
   )
 }
 
@@ -59,6 +54,12 @@ export default async function loadSettings(dir: string) {
   try {
     const currentSettings = await api.client.request(readSettings())
     const mergedSettings = customDefu(currentSettings as any, settings) as DirectusSettings
+
+    // @ts-ignore - ignore
+    delete mergedSettings.license_key
+    // @ts-ignore - ignore
+    delete mergedSettings.license_token
+
     await api.client.request(updateSettings(mergedSettings))
   } catch (error) {
     catchError(error)


### PR DESCRIPTION
When merging settings, the CLI tries to read and update the license_key and license_token. This is prohibited so we need to manually delete these attributes when updating the project settings.

https://github.com/directus/directus/blob/main/api/src/services/settings.ts#L24

The DirectusSettings type outdated. Should this be included in the PR to match V12 Settings type?