### PR TITLE
fix(extract): handle singleton collections in getCollectionItems (#144)

### DIFF
--- a/src/lib/extract/extract-content.ts
+++ b/src/lib/extract/extract-content.ts
@@ -42,16 +42,20 @@ async function getCollections(relations: RelationInfo[], plan?: TemplatePlan) {
     .filter((collection) => !brokenJunctions.has(collection))
 }
 
-async function getCollectionItems(collection: string): Promise<Record<string, unknown>[]> {
+async function getCollectionItems(
+  collection: string,
+): Promise<Record<string, unknown> | Record<string, unknown>[]> {
   const items: Record<string, unknown>[] = []
   let page = 1
 
   while (true) {
     // eslint-disable-next-line no-await-in-loop
-    const response = (await api.client.request(readItems(collection as never, {limit: PAGE_SIZE, page}))) as Record<
-      string,
-      unknown
-    >[]
+    const response = (await api.client.request(readItems(collection as never, {limit: PAGE_SIZE, page}))) as
+      | Record<string, unknown>
+      | Record<string, unknown>[]
+    // Singletons return a single object — return it as-is so the file stays an object,
+    // matching loadSingletons/updateSingleton on the load side.
+    if (!Array.isArray(response)) return response
     items.push(...response)
 
     if (response.length < PAGE_SIZE) break
@@ -137,14 +141,17 @@ async function getDataFromCollection(
   try {
     ux.action.status = `Extracting content: ${collection}`
     const response = await getCollectionItems(collection)
+    // Relation-stripping works on rows and mutates in place; a singleton is one object,
+    // so normalise to an array for those passes but write the original shape.
+    const items = Array.isArray(response) ? response : [response]
     const excludedRelations = getExcludedRelationFields(collection, relations, plan)
 
     if (plan?.relationStrategy === 'empty') {
-      emptyExcludedRelations(response, excludedRelations)
+      emptyExcludedRelations(items, excludedRelations)
     }
 
     const warnings =
-      plan?.relationStrategy === 'preserve' ? getBrokenRelationWarnings(collection, response, excludedRelations) : []
+      plan?.relationStrategy === 'preserve' ? getBrokenRelationWarnings(collection, items, excludedRelations) : []
 
     await writeToFile(`${collection}`, response, `${dir}/content/`)
     return warnings


### PR DESCRIPTION
Fixes #144.

`extract` (with content) crashes when the source instance has **singleton collections**, because `getCollectionItems` assumes `readItems()` always returns an array:

```ts
const response = (await api.client.request(readItems(collection, {limit, page}))) as Record<string, unknown>[]
items.push(...response)            // singleton → object, not iterable
if (response.length < PAGE_SIZE) break
```

For a singleton, the SDK resolves to the single item **object**, so `...response` throws `Spread syntax requires ...iterable[Symbol.iterator] to be a function` and `response.length` is `undefined`. The extract aborts at the first singleton (alphabetically) and writes no content for it or any collection after it.

### Fix

Guard the non-array response — wrap a singleton object in an array:

```ts
const rows = Array.isArray(response) ? response : response ? [response] : []
items.push(...rows)
if (rows.length < PAGE_SIZE) break
```

### Verification

- `tsc -b` builds clean.
- With this change, a full `extract` with content completes on an instance that has singleton collections (reproduced with Agency OS's `globals`, `os_settings`, `pages_blog`, `pages_projects`). The crash was independently confirmed by another reporter in #144 on a different Node version.

Single-file change; non-singleton collections keep the existing array path unchanged.
